### PR TITLE
Make Cash Address the Default Address Format

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/CashAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/CashAddress.java
@@ -33,50 +33,14 @@ package org.bitcoinj.core;
 
 public class CashAddress extends Address {
 
-    public enum CashAddressType {
-        PubKey(0),
-        Script(1);
-
-        private int value;
-
-        CashAddressType(int value) {
-            this.value = value;
-        }
-
-        byte getValue() {
-            return (byte) value;
-        }
-    }
-
-    private CashAddressType addressType;
-
-    static int getLegacyVersion(NetworkParameters params, CashAddressType type) {
-        switch (type) {
-            case PubKey:
-                return params.getAddressHeader();
-            case Script:
-                return params.getP2SHHeader();
-        }
-        throw new AddressFormatException("Invalid Cash address type: " + type.value);
-    }
-
-    static CashAddressType getType(NetworkParameters params, int version) {
-        if (version == params.getAddressHeader()) {
-            return CashAddressType.PubKey;
-        } else if (version == params.getP2SHHeader()) {
-            return CashAddressType.Script;
-        }
-        throw new AddressFormatException("Invalid Cash address version: " + version);
-    }
-
     CashAddress(NetworkParameters params, CashAddressType addressType, byte[] hash) {
         super(params, getLegacyVersion(params, addressType), hash);
-        this.addressType = addressType;
+        this.cashAddressType = addressType;
     }
 
     CashAddress(NetworkParameters params, int version, byte[] hash160) {
         super(params, version, hash160);
-        this.addressType = getType(params, version);
+        this.cashAddressType = getType(params, version);
     }
 
     /**
@@ -84,16 +48,16 @@ public class CashAddress extends Address {
      * See also https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki: Address Format for pay-to-script-hash
      */
     public boolean isP2SHAddress() {
-        return addressType == CashAddressType.Script;
+        return cashAddressType == CashAddressType.Script;
     }
 
     public CashAddressType getAddressType() {
-        return addressType;
+        return cashAddressType;
     }
 
     public String toString() {
         return CashAddressHelper.encodeCashAddress(getParameters().getCashAddrPrefix(),
-                CashAddressHelper.packAddressData(getHash160(), addressType.getValue()));
+                CashAddressHelper.packAddressData(getHash160(), cashAddressType.getValue()));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/CashAddressFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/CashAddressFactory.java
@@ -85,7 +85,7 @@ public class CashAddressFactory {
      * @param addr
      *            The textual form of the address, such as "bitcoincash:qpk4hk3wuxe2uqtqc97n8atzrrr6r5mleczf9sur4h".
      * @throws AddressFormatException
-     *             if the given base58 doesn't parse or the checksum is invalid
+     *             if the given cash address doesn't parse or the checksum is invalid
      * @throws WrongNetworkException
      *             if the given address is valid but for a different chain (eg testnet vs mainnet)
      */

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -63,10 +63,9 @@ public class SendMoneyController {
     }
 
     public void send(ActionEvent event) {
-        // Address exception cannot happen as we validated it beforehand.
         try {
             Coin amount = Coin.parseCoin(amountEdit.getText());
-            Address destination = Address.fromBase58(Main.params, address.getText());
+            Address destination = Address.fromAddressString(Main.params, address.getText());
             SendRequest req;
             if (amount.equals(Main.bitcoin.wallet().getBalance()))
                 req = SendRequest.emptyWallet(destination);

--- a/wallettemplate/src/main/java/wallettemplate/controls/BitcoinAddressValidator.java
+++ b/wallettemplate/src/main/java/wallettemplate/controls/BitcoinAddressValidator.java
@@ -14,9 +14,7 @@
 
 package wallettemplate.controls;
 
-import org.bitcoinj.core.Address;
-import org.bitcoinj.core.AddressFormatException;
-import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.*;
 import javafx.scene.Node;
 import javafx.scene.control.TextField;
 import wallettemplate.utils.TextFieldValidator;
@@ -45,12 +43,13 @@ public class BitcoinAddressValidator {
 
     private void toggleButtons(String current) {
         boolean valid = testAddr(current);
-        for (Node n : nodes) n.setDisable(!valid);
+        for (Node n : nodes)
+            n.setDisable(!valid);
     }
 
     private boolean testAddr(String text) {
         try {
-            Address.fromBase58(params, text);
+            Address.fromAddressString(params, text);
             return true;
         } catch (AddressFormatException e) {
             return false;


### PR DESCRIPTION
- move CashAddressType enum and private variable, and getLegacyVersion and getType functions from CashAddress to parent class Address
- rename addressType to cashAddressType and add Unknown to enum
- set cashAddressType in Address constructors
- add fromCashAddress and fromAddressString constructors to Address
- Overwrite toString on Address to return CashAddress format
- fix comment in CashAddressFactory
- update walletTemplate to use fromAddressString instead of fromBase58