### PR TITLE
Add CHECKSEQUENCEVERIFY and OP_CHECKDATASIG support

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -98,6 +98,8 @@ public abstract class NetworkParameters {
     protected int daaUpdateHeight;
     // May, 15 2018 hard fork
     protected long monolithActivationTime = 1526400000L;
+    // Nov, 15 2018 hard fork
+    protected static long november2018ActivationTime = 1542300000L;
 
     /**
      * See getId(). This may be null for old deserialized wallets. In that case we derive it heuristically
@@ -531,7 +533,10 @@ public abstract class NetworkParameters {
             tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) > this.getMajorityEnforceBlockUpgrade()) {
             verifyFlags.add(Script.VerifyFlag.CHECKLOCKTIMEVERIFY);
         }
-
+        // Start enforcing CHECKDATASIG, if November 15 2018 hardfork reached
+        if (block.getTimeSeconds() >= NetworkParameters.november2018ActivationTime) {
+            verifyFlags.add(Script.VerifyFlag.CHECKDATASIG);
+        }
         return verifyFlags;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -50,6 +50,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class TransactionInput extends ChildMessage {
     /** Magic sequence number that indicates there is no sequence number. */
     public static final long NO_SEQUENCE = 0xFFFFFFFFL;
+
+    /** Below flags apply in the context of BIP 68 */
+    // If this flag set, nSequence is NOT interpreted as a relative lock-time.
+    public static final long SEQUENCE_LOCKTIME_DISABLE_FLAG = 1L << 31;
+    /** If nSequence encodes a relative lock-time and this flag is set, the relative lock-time has units of
+     * 512 seconds, otherwise it specifies blocks with a granularity of 1. */
+    public static final long SEQUENCE_LOCKTIME_TYPE_FLAG = 1L << 22;
+    /** If CTxIn::nSequence encodes a relative lock-time, this mask is applied to extract that lock-time from the
+     * sequence field. */
+    public static final long SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+
     private static final byte[] EMPTY_ARRAY = new byte[0];
     // Magic outpoint index that indicates the input is in fact unconnected.
     private static final long UNCONNECTED = 0xFFFFFFFFL;

--- a/core/src/main/java/org/bitcoinj/script/ScriptOpCodes.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptOpCodes.java
@@ -86,9 +86,9 @@ public class ScriptOpCodes {
 
     // splice ops
     public static final int OP_CAT = 0x7e;
-    public static final int OP_SPLIT = 0x7f;
-    public static final int OP_NUM2BIN = 0x80;
-    public static final int OP_BIN2NUM = 0x81;
+    public static final int OP_SPLIT = 0x7f; // after monolith upgrade (May 2018)
+    public static final int OP_NUM2BIN = 0x80; // after monolith upgrade (May 2018)
+    public static final int OP_BIN2NUM = 0x81; // after monolith upgrade (May 2018)
     public static final int OP_SIZE = 0x82;
 
     // bit logic
@@ -145,13 +145,35 @@ public class ScriptOpCodes {
     // block state
     /** Check lock time of the block. Introduced in BIP 65, replacing OP_NOP2 */
     public static final int OP_CHECKLOCKTIMEVERIFY = 0xb1;
+    /** Check sequence verify - prevents non-final transaction from being included in a block until the input has
+     *  reached the given age. Introduced in BIP 112, replacing OP_NOP3 */
+    public static final int OP_CHECKSEQUENCEVERIFY = 0xb2;
+
+    // additional crypto
+    /** Check whether a signature is valid with respect to a message hash and and a public key. */
+    public static final int OP_CHECKDATASIG = 0xba;
+    public static final int OP_CHECKDATASIGVERIFY = 0xbb;
+    // multi-byte opcodes
+    /**
+     * Reserved range for multi-byte opcodes
+     * per https://github.com/Bitcoin-ABC/bitcoin-abc/commit/b76f72e9e684fd19b300e59fd1de590cd1b46b48
+     */
+    public static final int OP_PREFIX_BEGIN = 0xf0;
+    public static final int OP_PREFIX_END = 0xf7;
+    // template matching params
+    // *NOT* real opcodes.  If found in real Script, they can be interpreted as OP_UNKNOWN
+    public static final int OP_SMALLINTEGER = 0xfa;
+    public static final int OP_PUBKEYS = 0xfb;
+    public static final int OP_PUBKEYHASH = 0xfd;
+    public static final int OP_PUBKEY = 0xfe;
 
     // expansion
     public static final int OP_NOP1 = 0xb0;
     /** Deprecated by BIP 65 */
     @Deprecated
     public static final int OP_NOP2 = OP_CHECKLOCKTIMEVERIFY;
-    public static final int OP_NOP3 = 0xb2;
+    /** Deprecated by BIP 112 */
+    public static final int OP_NOP3 = OP_CHECKSEQUENCEVERIFY;
     public static final int OP_NOP4 = 0xb3;
     public static final int OP_NOP5 = 0xb4;
     public static final int OP_NOP6 = 0xb5;
@@ -266,14 +288,16 @@ public class ScriptOpCodes {
         .put(OP_CHECKMULTISIGVERIFY, "CHECKMULTISIGVERIFY")
         .put(OP_NOP1, "NOP1")
         .put(OP_CHECKLOCKTIMEVERIFY, "CHECKLOCKTIMEVERIFY")
-        .put(OP_NOP3, "NOP3")
+        .put(OP_CHECKSEQUENCEVERIFY, "CHECKSEQUENCEVERIFY")
         .put(OP_NOP4, "NOP4")
         .put(OP_NOP5, "NOP5")
         .put(OP_NOP6, "NOP6")
         .put(OP_NOP7, "NOP7")
         .put(OP_NOP8, "NOP8")
         .put(OP_NOP9, "NOP9")
-        .put(OP_NOP10, "NOP10").build();
+        .put(OP_NOP10, "NOP10")
+        .put(OP_CHECKDATASIG, "CHECKDATASIG")
+        .put(OP_CHECKDATASIGVERIFY, "CHECKDATASIGVERIFY").build();
 
     private static final Map<String, Integer> opCodeNameMap = ImmutableMap.<String, Integer>builder()
         .put("0", OP_0)
@@ -379,7 +403,7 @@ public class ScriptOpCodes {
         .put("CHECKMULTISIGVERIFY", OP_CHECKMULTISIGVERIFY)
         .put("NOP1", OP_NOP1)
         .put("CHECKLOCKTIMEVERIFY", OP_CHECKLOCKTIMEVERIFY)
-        .put("NOP2", OP_NOP2)
+        .put("CHECKSEQUENCEVERIFY", OP_CHECKSEQUENCEVERIFY)
         .put("NOP3", OP_NOP3)
         .put("NOP4", OP_NOP4)
         .put("NOP5", OP_NOP5)
@@ -387,7 +411,9 @@ public class ScriptOpCodes {
         .put("NOP7", OP_NOP7)
         .put("NOP8", OP_NOP8)
         .put("NOP9", OP_NOP9)
-        .put("NOP10", OP_NOP10).build();
+        .put("NOP10", OP_NOP10)
+        .put("CHECKDATASIG", OP_CHECKDATASIG)
+        .put("CHECKDATASIGVERIFY", OP_CHECKDATASIGVERIFY).build();
 
     /**
      * Converts the given OpCode into a string (eg "0", "PUSHDATA", or "NON_OP(10)")


### PR DESCRIPTION
- add opcodes to ScriptOpCodes class, opCodeMap, and Map
- add SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG, and SEQUENCE_LOCKTIME_MASK constants from BIP68 to TransactionInput
- count OP_CHECKDATASIG(VERIFY) as 1 sigop per spec
- remove unneeded params in private executeCheckLockTimeVerify function
- add OP_CHECKDATASIG(VERIFY) handling in the Script class